### PR TITLE
Update run-igmpproxy.sh

### DIFF
--- a/run-igmpproxy.sh
+++ b/run-igmpproxy.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-/mnt/data/igmpproxy/igmpproxy /mnt/data/igmpproxy/igmpproxy.conf
+/data/igmpproxy/igmpproxy /data/igmpproxy/igmpproxy.conf


### PR DESCRIPTION
With the update to 2.4.27 the /mnt/ is no longer used. The igmpproxy folder will need to be made at /data/igmpproxy